### PR TITLE
Bugfix/fix concat bytes

### DIFF
--- a/bme680/build.gradle
+++ b/bme680/build.gradle
@@ -22,6 +22,7 @@ android {
 dependencies {
     compileOnly 'com.google.android.things:androidthings:1.0'
     implementation 'com.android.support:support-annotations:27.1.1'
+    testImplementation 'junit:junit:4.12'
 }
 
 apply from: 'install.gradle'

--- a/bme680/src/main/java/com/knobtviker/android/things/contrib/community/driver/bme680/Bme680.java
+++ b/bme680/src/main/java/com/knobtviker/android/things/contrib/community/driver/bme680/Bme680.java
@@ -459,11 +459,11 @@ public class Bme680 implements AutoCloseable {
         calibration.pressure[0] = concatBytes(mCalibrationArray[BME680_P1_MSB_REGISTER], mCalibrationArray[BME680_P1_LSB_REGISTER], false);
         calibration.pressure[1] = concatBytes(mCalibrationArray[BME680_P2_MSB_REGISTER], mCalibrationArray[BME680_P2_LSB_REGISTER], true);
         calibration.pressure[2] = mCalibrationArray[BME680_P3_REGISTER];
-        calibration.pressure[3] = concatBytes(mCalibrationArray[BME680_P4_MSB_REGISTER], mCalibrationArray[BME680_P4_LSB_REGISTER], false);
+        calibration.pressure[3] = concatBytes(mCalibrationArray[BME680_P4_MSB_REGISTER], mCalibrationArray[BME680_P4_LSB_REGISTER], true);
         calibration.pressure[4] = concatBytes(mCalibrationArray[BME680_P5_MSB_REGISTER], mCalibrationArray[BME680_P5_LSB_REGISTER], true);
         calibration.pressure[5] = mCalibrationArray[BME680_P6_REGISTER];
         calibration.pressure[6] = mCalibrationArray[BME680_P7_REGISTER];
-        calibration.pressure[7] = concatBytes(mCalibrationArray[BME680_P8_MSB_REGISTER], mCalibrationArray[BME680_P8_LSB_REGISTER], false);
+        calibration.pressure[7] = concatBytes(mCalibrationArray[BME680_P8_MSB_REGISTER], mCalibrationArray[BME680_P8_LSB_REGISTER], true);
         calibration.pressure[8] = concatBytes(mCalibrationArray[BME680_P9_MSB_REGISTER], mCalibrationArray[BME680_P9_LSB_REGISTER], true);
         calibration.pressure[9] = mCalibrationArray[BME680_P10_REGISTER] & 0xFF;
 
@@ -855,9 +855,9 @@ public class Bme680 implements AutoCloseable {
 
     private int concatBytes(final int msb, final int lsb, final boolean isSigned) {
         if (isSigned) {
-            return ((msb << 8) | lsb);
+            return (msb << 8) | (lsb & 0xff); // keep the sign of msb but not of lsb
         } else {
-            return (((msb & 0xFF) << 8) | (lsb & 0xFF));
+            return ((msb & 0xff) << 8) | (lsb & 0xff);
         }
     }
 

--- a/bme680/src/test/java/com/knobtviker/android/things/contrib/community/driver/bme680/Bme680Test.java
+++ b/bme680/src/test/java/com/knobtviker/android/things/contrib/community/driver/bme680/Bme680Test.java
@@ -1,0 +1,133 @@
+package com.knobtviker.android.things.contrib.community.driver.bme680;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+public class Bme680Test {
+
+    // copy of the method in Bme680.java
+    private static int concatBytes(final int msb, final int lsb, final boolean isSigned) {
+        if (isSigned) {
+            return (msb << 8) | (lsb & 0xff); // keep the sign of msb but not of lsb
+        } else {
+            return ((msb & 0xff) << 8) | (lsb & 0xff);
+        }
+    }
+
+    /*
+Example calibration data provided by c-driver:
+----------------------------------------------
+
+par_gh1: -31
+par_gh2: -13193
+par_gh3: 18
+par_h1: 846
+par_h2: 997
+par_h3: 0
+par_h4: 45
+par_h5: 20
+par_h6: 120
+par_h7: -100
+par_p1: 36236
+par_p10: 30
+par_p2: -10417
+par_p3: 88
+par_p4: 6248
+par_p5: -28
+par_p6: 30
+par_p7: 45
+par_p8: -3060 -> 62476 at Android driver
+par_p9: -2427 -> -123 at Android driver
+par_t1: 26353
+par_t2: 26261 -> -107 at Android driver
+par_t3: 3
+range_sw_err: 0
+res_heat_range: 1
+res_heat_val: 49
+     */
+
+    @Test
+    public void should_calculate_the_right_value_T1() {
+        byte msb = 102;
+        byte lsb = -15; // 241
+        int i = concatBytes(msb, lsb, false);
+
+        assertThat(i, CoreMatchers.equalTo(26353));
+    }
+
+    @Test
+    public void should_calculate_the_right_value_T2() {
+        byte msb = 102;
+        byte lsb = -107; // 149
+        int i = concatBytes(msb, lsb, true);
+
+        assertThat(i, CoreMatchers.equalTo(26261));
+    }
+
+    @Test
+    public void should_calculate_the_right_value_P1() {
+        byte msb = -115; // 141
+        byte lsb = -116; // 140
+        int i = concatBytes(msb, lsb, false);
+
+        assertThat(i, CoreMatchers.equalTo(36236));
+    }
+
+    @Test
+    public void should_calculate_the_right_value_P2() {
+        byte msb = -41; // 215
+        byte lsb = 79;
+        int i = concatBytes(msb, lsb, true);
+
+        assertThat(i, CoreMatchers.equalTo(-10417));
+    }
+
+    @Test
+    public void should_calculate_the_right_value_P4() {
+        byte msb = 24;
+        byte lsb = 104;
+        int i = concatBytes(msb, lsb, true);  // should be 'true' according to c-driver
+
+        assertThat(i, CoreMatchers.equalTo(6248));
+    }
+
+    @Test
+    public void should_calculate_the_right_value_P5() {
+        byte msb = -1; // 255
+        byte lsb = -28; // 228
+        int i = concatBytes(msb, lsb, true);
+
+        assertThat(i, CoreMatchers.equalTo(-28));
+    }
+
+    @Test
+    public void should_calculate_the_right_value_P8() {
+        byte msb = -12; // 244
+        byte lsb = 12;
+        int i = concatBytes(msb, lsb, true); // should be 'true' according to c-driver
+
+        assertThat(i, CoreMatchers.equalTo(-3060));
+    }
+
+    @Test
+    public void should_calculate_the_right_value_P9() {
+        byte msb = -10; // 246
+        byte lsb = -123; // 133
+        int i = concatBytes(msb, lsb, true);
+
+        assertThat(i, CoreMatchers.equalTo(-2427));
+    }
+
+    @Test
+    public void should_calculate_the_right_value_GH2() {
+        byte msb = -52; // 204
+        byte lsb = 119;
+        int i = concatBytes(msb, lsb, true);
+
+        assertThat(i, CoreMatchers.equalTo(-13193));
+    }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
 
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'


### PR DESCRIPTION
This request should fix the buggy byte concatenation during calibration.

I added a test file to demonstrate the problematic spots based on the calibration data of my sensor. Since I need some configuration around you may cherry-pick the relevant changes in `Bme680.java`.


_Hints:_

After purchasing a _BME 680_ and connected to my Raspi via _Android Things_ using this driver, the driver measured some weird values (temperature staying around 0.09°C and pressure above 1200mBar). I tested the available [c-driver](https://github.com/BoschSensortec/BME680_driver) on plain Linux and the values were as expected.
After debugging both driver I figured out that the calibration data differs. I've got 3 differences that I fixed by comparing your code against the c-driver.